### PR TITLE
Added `make build-images` step to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ cd path/to/rootski/
 source ./venv/bin/activate  # required for pre-commit hooks to work!
 make install
 
+# build docker image for the backend API
+make build-images
+
 cd ./rootski_api/
 make install  # install backend specific python requirements
 make run-local-db

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ source ./venv/bin/activate
 # install pre-commit, git-lfs, DVC, xonsh, and other utilities needed to run makefile targets
 make install
 
+# build docker images to run the backend API and a development server for the frontend
+make build-images
+
 # run the frontend and backend locally in docker
 make run
 ```


### PR DESCRIPTION
Nikhil Gulwade pointed out that you can't just run `make run` and always expect the app to work. You need to do `make build-images` first.