### PR TITLE
sphinx -- rootski docs and knowledge base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@
 # location if this is a PR and to the production location otherwise.
 # When a PR is merged, the published docs from the review are cleaned up.
 
-name: build
+name: build-and-publish-docs
 
 on:
   push:
@@ -46,27 +46,24 @@ jobs:
       - name: make RECENT_MERGED_BRANCH_NAME variable available
         uses: tonynguyenit18/github-action-custom-vars@v1
 
-      # - name: install docker
-      #   uses: docker-practice/actions-setup-docker@1.0.8
+      - name: install docker
+        uses: docker-practice/actions-setup-docker@1.0.8
 
-      # - name: install dependencies
-      #   run: |
-      #     cd ./docs/
+      - name: install dependencies
+        run: |
+          cd ./docs/
 
-      #     # install all python dependencies of the project
-      #     make build-image
+          # install all python dependencies of the project
+          make build-image
 
-      #     # build the docs and write to rootski/docs/build/html/
-      #     make docs-docker
+          # build the docs and write to rootski/docs/build/html/
+          make docs-docker
 
       - name: publish docs
         env:
           IS_PR: ${{ github.EVENT_NAME == 'pull_request' }}
         run: |
           cd ./docs/
-
-          mkdir -p ./build/html/
-          echo "Hi everyone!!!" >> ./build/html/index.html
 
           # invalidate the S3 cache to prepare to publish the new site
           pip install boto3
@@ -91,6 +88,7 @@ jobs:
           fi
 
       - uses: actions-ecosystem/action-create-comment@v1
+        if: github.event_name == 'pull_request'
         with:
           github_token: ${{ secrets.github_token }}
           body: |

--- a/.vscode/rootski-python-docstring-template.mustache
+++ b/.vscode/rootski-python-docstring-template.mustache
@@ -1,0 +1,20 @@
+{{! Sphinx Docstring Template without Types for Args, Returns or Yields }}
+{{summaryPlaceholder}}
+
+{{extendedSummaryPlaceholder}}
+
+{{#args}}
+:param {{var}}: {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+:param {{var}}: {{descriptionPlaceholder}}
+{{/kwargs}}
+{{#exceptions}}
+:raises {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{#returns}}
+:return: {{descriptionPlaceholder}}
+{{/returns}}
+{{#yields}}
+:yield: {{descriptionPlaceholder}}
+{{/yields}}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "restructuredtext.confPath": "",
+    "autoDocstring.customTemplatePath": "./.vscode/rootski-python-docstring-template.mustache",
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": ["--rcfile=./linting/.pylintrc"],
+    "python.formatting.provider": "black",
+    "python.formatting.blackArgs": ["--line-length=112"],
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+        "--config==./linting/.flake8",
+        "--max-line-length=112"
+    ]
+}

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@
 
    * - :fa:`youtube` `YouTube Playlist <https://www.youtube.com/playlist?list=PLwF2z4Iu4rabmY7RbRNetjZprLfe8qWNz>`_
      - Training videos walking through the architecture, tools, and how to contribute to rootski.
-   * - :fa:`aws` `AWS console sign in<https://rootski.signin.aws.amazon.com/console>`_
+   * - :fa:`aws` `AWS console sign in <https://rootski.signin.aws.amazon.com/console>`_
      - .. code:: text
 
            https://rootski.signin.aws.amazon.com/console

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -75,12 +75,6 @@ WORKDIR /rootski/docs
 COPY ./docs/requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
-
-# change to a new user because drawio-desktop raises an error when run as root
-RUN useradd -ms /bin/bash sphinx-user
-RUN chown -R sphinx-user:sphinx-user /rootski
-USER sphinx-user
-
 COPY ./docs/Makefile ./Makefile
 
 ENTRYPOINT ["make"]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,7 +33,8 @@ build-image:
 # use the docker image to build the docs
 docs-docker:
 	mkdir -p $(BUILDDIR)/html
-	docker-compose up
+	mkdir -p $(BUILDDIR)/doctrees
+	docker-compose run --rm sphinx
 
 # use the docker image to
 serve-docker:

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.9"
 services:
 
   sphinx:
-    privileged: true
     image: rootski/sphinx
     build:
       dockerfile: docs/Dockerfile

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,7 @@ def is_mac_os():
 
 # drawio_binary_path = "/usr/local/bin/drawio"
 drawio_binary_path = "/Applications/draw.io.app/Contents/MacOS/draw.io" if is_mac_os() else "/opt/drawio/drawio"
+drawio_no_sandbox = not is_mac_os()
 drawio_headless = "auto"
 
 autosummary_generate = True  # Turn on sphinx.ext.autosummary

--- a/rootski_api/src/rootski/config/config.py
+++ b/rootski_api/src/rootski/config/config.py
@@ -280,7 +280,8 @@ class Config(BaseSettings):
             )
 
     def __init__(self, **kwargs):
-        # set all of the settings values using ``customise_sources``
+        # The tests seem to fail without this empty __init__
+        # pylint: disable=useless-super-delegation
         super().__init__(**kwargs)
 
 

--- a/rootski_api/src/rootski/config/config.py
+++ b/rootski_api/src/rootski/config/config.py
@@ -15,17 +15,17 @@ be prioritized in the following order:
     the environment variable equivalent will be ROOTSKI__NAME.
 """
 
+import json
 import os
 from enum import Enum
-import json
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
-from rootski.config.ssm import get_ssm_parameters_by_prefix
 
 import yaml
 from pydantic import AnyHttpUrl, BaseSettings, validator
 from pydantic.dataclasses import dataclass
 from pydantic.env_settings import SettingsSourceCallable
+from rootski.config.ssm import get_ssm_parameters_by_prefix
 
 ANON_USER = "anon@rootski.io"
 ENVIRON_PREFIX: str = "ROOTSKI__"
@@ -278,6 +278,10 @@ class Config(BaseSettings):
                 aws_parameter_store_settings_source,  # values from ssm parameter store
                 file_secret_settings,  # ???
             )
+
+    def __init__(self, **kwargs):
+        # set all of the settings values using ``customise_sources``
+        super().__init__(**kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I am _so proud_ of this PR!

I snuck another PR in that changed 100+ files before this, so not all the relevant changes are in this one (sorry for the bad example).

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/32227767/156737586-35894b85-ff55-4e33-9f47-efdeb73e990b.png">

We have the beginnings of a documentation system with some _incredible_ features!

1. An **autogenerated API reference section** in the sidebar that lets us browse most of our Python code including tests. The pages are **generated from our docstrings**.
2. We can use the reStructuredText markdown language in our function, class, and module docstrings to do some bring our documentation to life:
  a. write LaTeX math equations that render on the site! (We could definitely use this for modeling)
  b. render .drawio diagrams! With the VS Code drawio extension, we can commit `.drawio` files to our repo and create diagrams. Then, we can use the `.. drawio-image: path/to/diagram.drawio` in a module docstring (for example) and render the diagram! I tried this out for some [infrastructure as code, here](https://docs.rootski.io/infrastructure_autosummary/s3_static_site.html)
3. When you open a PR (and each time you add commits to the PR thereafter), the docs are built and published to a "review" URL at `docs.rootski.io/review/<your branch name>/`. GitHub will automatically comment to the PR discussion with the link to your docs! That means if you make changes to docs in your PR, we can see the rendered version of your docs to review them and send each other screenshots to discuss without having to checkout your branch locally and build them ourselves. 
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/32227767/156746918-34896aca-1651-4348-933a-afc35fa1e964.png">. When you merge your PR, these "review" docs are cleaned up to save storage costs, and then the docs are rebuilt and published to docs.rootski.io. Please read through our new [docs CI workflow](./.github/workflows/docs.yml) (./.github/workflows/) to see how this all works. It's actually quite simple!
4. We can write long-form tutorials, how-to's, etc. and add auto-updating hyperlinks to functions in our code that take you to the "code viewer" in the UI.
5. We can embed portions of code files intermixed with our articles. These will never get stale, because you include them by adding a reference to a file and the code snippets get generated.
6. The docs build is dockerized. Building the docs requires `draw.io-desktop`, `nodejs`, all python packages, and the `aws-cdk` CLI to all be installed. Docker makes this significantly easier for people to work with. A new contributor can run these commands, to build and view the docs without needing anything but `docker` and `cmake` on their system.

```bash
cd rootski/docs/
make build-image
make docs-docker
make serve-docker
```

Here's a diagram of the architecture for how the site is hosted. I was able to add this into the module docstring of the AWS CDK code that I wrote for the site: 
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/32227767/156748949-968b5be2-6524-4a40-a947-6180f1434645.png">

Here's the docstring that causes the above diagram to appear in the site. It's in `infrastructure/iac/aws-cdk/backend/s3_static_site/__init__.py`. I think I will do this for every piece of infrastructure as code that we have.
<img width="753" alt="image" src="https://user-images.githubusercontent.com/32227767/156749133-81c4709e-725a-4191-b3a4-21b7d712ea5a.png">


There are many more features that are set up, but this message is already long. I'll use this tool to write a tutorial... about how to use this tool :)

The actual content of the website has yet to be decided. It's still very much a work in progress. But the groundwork has been laid to do some really amazing things in that area. We will eventually deprecate Notion as our knowledge base once we've moved the content over to here.