### PR TITLE
Cu 2g3hb45 deploy backup solution to the lightsail instance isaac robbins

### DIFF
--- a/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
+++ b/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
@@ -111,7 +111,7 @@ EOF
 cd /home/ec2-user
 [[ -d /home/ec2-user/rootski ]] \
     || GIT_SSH_COMMAND='ssh -F /home/ec2-user/.ssh/config' \
-    git clone --depth 1 -b CU-2g3hb45_Deploy-backup-solution-to-the-lightsail-instance_Isaac-Robbins git@github.com:rootski-io/rootski.git
+    git clone --depth 1 git@github.com:rootski-io/rootski.git
 
 # deploy docker stack
 cd rootski

--- a/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
+++ b/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
@@ -128,11 +128,11 @@ make install-lightsail
 make build-images
 
 # runs the postgres and database-backup containers in a swarm
-make start-database-stack
+make start-database-stack-lightsail
 
 # waits until the database is initialized and restores the database from
 # the most recent S3 backup
-make restore-database-from-most-recent-s3-backup
+make restore-database-from-s3
 
 # sets the database to backup to S3 continually on an interval
 make backup-database-to-s3-on-interval

--- a/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
+++ b/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
@@ -127,8 +127,10 @@ make install-lightsail
 # builds the docker images for the postgres and database-backup contaienrs
 make build-images
 
-# runs the postgres and database-backup containers in a swarm
+# runs the postgres and database-backup containers in a swarm and sleeps
+# to give the containers time to start up
 make start-database-stack-lightsail
+sleep 5
 
 # waits until the database is initialized and restores the database from
 # the most recent S3 backup

--- a/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
+++ b/infrastructure/iac/aws-cdk/backend/rootski_backend_cdk/database/lightsail/stacks/resources/user-data.template.sh
@@ -111,7 +111,7 @@ EOF
 cd /home/ec2-user
 [[ -d /home/ec2-user/rootski ]] \
     || GIT_SSH_COMMAND='ssh -F /home/ec2-user/.ssh/config' \
-    git clone --depth 1 git@github.com:rootski-io/rootski.git
+    git clone --depth 1 -b CU-2g3hb45_Deploy-backup-solution-to-the-lightsail-instance_Isaac-Robbins git@github.com:rootski-io/rootski.git
 
 # deploy docker stack
 cd rootski


### PR DESCRIPTION
Fixed two more issues from the last merge to trunk:
- Updated the make targets in the `user-data.template.sh` file which did not match the actual make targets
- the `parse_timedelta` function in `backup_or_restore.py` was parsing "24h" as 0 s causing the database to backup to S3 as fast as it could. I rewrote the function so that it properly parses the time strings

I have tested all of the changes and the database is currently running, having only run the `python make.py` command and the backup on interval is working as expected. 