### PR TITLE
Feature/migrate words endpoint to dynamo

### DIFF
--- a/rootski_api/Makefile
+++ b/rootski_api/Makefile
@@ -7,6 +7,7 @@
 # also install the rootski_api project
 install:
 	python -m pip install xonsh colorama pre-commit
+	python -m pip install -e ../make_utils
 	python -m pip install -e .[dev]
 
 
@@ -23,8 +24,7 @@ help:
 	python -m xonsh make.xsh help
 
 
-# Generate a makefile from the targets registered with this instance of
-# the Makefile decorator.
+# Generate a makefile from the targets registered with this Makefile instance.
 make:
 	python -m xonsh make.xsh make
 

--- a/rootski_api/make.xsh
+++ b/rootski_api/make.xsh
@@ -64,6 +64,7 @@ def run():
     """Run the rootski api using the config values in config/rootski-config.yml"""
     rootski_config_fpath = str((THIS_DIR / "config/rootski-config.yml").resolve().absolute())
     $ROOTSKI__CONFIG_FILE_PATH = rootski_config_fpath
+    $AWS_PROFILE = "rootski"
     uvicorn "rootski.main.main:create_default_app" --factory --reload --port 3333
 
 

--- a/rootski_api/make.xsh
+++ b/rootski_api/make.xsh
@@ -9,20 +9,9 @@ from textwrap import dedent
 from glob import glob
 from copy import deepcopy
 
-
-# manually add ../make_utils/ to PYTHONPATH so we can import resources from make_utils
-THIS_DIR = Path(__file__).parent.absolute()
-MAKE_UTILS_DIR = (THIS_DIR / "..").resolve().absolute()
-sys.path.insert(0, str(MAKE_UTILS_DIR))
-
-# manually add ./make_utils/ to PYTHONPATH so we can import from the make_utils module
-THIS_DIR = Path(__file__).parent.absolute()
-sys.path.insert(0, str(THIS_DIR))
-
 from make_utils.utils_without_dependencies import print_import_error_help_message, get_localhost
 
 try:
-    import bcrypt
     from rich import print
     from rich.panel import Panel
     import configparser
@@ -44,12 +33,15 @@ from rich.console import Console
 # make tracebacks beautiful when errors occur 😃
 traceback.install()
 
+THIS_DIR = Path(__file__).parent
+
 
 CUSTOM_MAKE_TEXT = dedent(f"""
 # install dependencies for running other makefile targets;
 # also install the rootski_api project
 install:
 \tpython -m pip install xonsh colorama pre-commit
+\tpython -m pip install -e ../make_utils
 \tpython -m pip install -e .[dev]
 """)
 

--- a/rootski_api/setup.cfg
+++ b/rootski_api/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     asyncpg
     pydantic[email]
     boto3
+    boto3-stubs[dynamodb]
 
 
 [options.extras_require]

--- a/rootski_api/src/rootski/config/config.py
+++ b/rootski_api/src/rootski/config/config.py
@@ -47,6 +47,8 @@ YAML_CONFIG_PATH_ENV_VAR: str = f"{ENVIRON_PREFIX}CONFIG_FILE_PATH"
 DEPLOYMENT_ENVIRONMENT_ENV_VAR = f"{ENVIRON_PREFIX}ENVIRONMENT"
 DEFAULT_DEPLOYMENT_ENVIRONMENT = "dev"
 
+DEFAULT_DYNAMO_TABLE_NAME = "rootski-table"
+
 # maps to a string boolean
 FETCH_VALUES_FROM_SSM_ENV_VAR = f"{ENVIRON_PREFIX}FETCH_VALUES_FROM_AWS_SSM"
 
@@ -184,6 +186,8 @@ class Config(BaseSettings):
     postgres_host: str
     postgres_port: str
     postgres_db: str
+
+    dynamo_table_name: str = DEFAULT_DYNAMO_TABLE_NAME
 
     @property
     def sync_sqlalchemy_database_uri(self) -> str:

--- a/rootski_api/src/rootski/main/main.py
+++ b/rootski_api/src/rootski/main/main.py
@@ -46,13 +46,17 @@ def create_app(
     @app.on_event("startup")
     async def on_startup():
         services: Services = app.state.services
+
         logging_service: LoggingService = services.logger
         auth_service: AuthService = services.auth
         db_service: DBService = services.db
+        dynamo_service: DynamoDBService = services.dynamo
+
         # logging should be initialized first since it alters a global logger variable
         logging_service.init()
         auth_service.init()
         db_service.init()
+        dynamo_service.init()
 
         # # ensure that the static assets dir exists (for morphemes.json)
         Path(config.static_assets_dir).mkdir(exist_ok=True, parents=True)

--- a/rootski_api/src/rootski/main/main.py
+++ b/rootski_api/src/rootski/main/main.py
@@ -8,12 +8,10 @@ To run this API with ``gunicorn``, use the following command:
     gunicorn rootski.main.main:create_app() --bind 0.0.0.0:3333
 """
 
-from typing import Optional
-from fastapi import FastAPI
-from starlette.middleware.cors import CORSMiddleware
-
 from pathlib import Path
+from typing import Optional
 
+from fastapi import FastAPI
 from rootski.config.config import Config
 from rootski.main.endpoints.breakdown.routes import router as breakdown_router
 from rootski.main.endpoints.graphql import router as graphql_router
@@ -23,10 +21,14 @@ from rootski.main.endpoints.word import router as word_router
 from rootski.schemas.core import Services
 from rootski.services.auth import AuthService
 from rootski.services.database import DBService
+from rootski.services.database.dynamo.db_service import DBService as DynamoDBService
 from rootski.services.logger import LoggingService
+from starlette.middleware.cors import CORSMiddleware
 
 
-def create_app(config: Optional[Config] = None) -> FastAPI:
+def create_app(
+    config: Optional[Config] = None,
+) -> FastAPI:
 
     if not config:
         config = Config()
@@ -37,6 +39,7 @@ def create_app(config: Optional[Config] = None) -> FastAPI:
         auth=AuthService.from_config(config=config),
         db=DBService.from_config(config=config),
         logger=LoggingService.from_config(config=config),
+        dynamo=DynamoDBService.from_config(config=config),
     )
 
     # configure startup behavior: initialize services on startup

--- a/rootski_api/src/rootski/schemas/__init__.py
+++ b/rootski_api/src/rootski/schemas/__init__.py
@@ -37,7 +37,23 @@ from .morpheme import (
     MorphemeInDb,
 )
 from .user import User, UserInDB
-from .word import WORD_POS_ENUM, Word, WordInDb
+from .word import (
+    WORD_POS_ENUM,
+    AdjectiveResponse,
+    AdjectiveShortForms,
+    Definition,
+    DefinitionForPOS,
+    ExampleSentence,
+    NounDeclensions,
+    NounResponse,
+    SubDefinition,
+    VerbAspectualPair,
+    VerbConjugations,
+    VerbResponse,
+    Word,
+    WordInDb,
+    WordResponse,
+)
 
 __all__ = [
     # breakdown
@@ -62,12 +78,23 @@ __all__ = [
     "User",
     "UserInDB",
     # word
+    "WORD_POS_ENUM",
     "Word",
     "WordInDb",
-    "WordPOS",
-    "WORD_POS_ENUM",
+    "SubDefinition",
+    "Definition",
+    "DefinitionForPOS",
+    "ExampleSentence",
+    "WordResponse",
+    "NounDeclensions",
+    "NounResponse",
+    "AdjectiveShortForms",
+    "AdjectiveResponse",
+    "VerbConjugations",
+    "VerbAspectualPair",
+    "VerbResponse",
     # core
-    "Services"
+    "Services",
     # morpheme types
     "MORPHEME_TYPE_PREFIX",
     "MORPHEME_TYPE_ROOT",

--- a/rootski_api/src/rootski/schemas/core.py
+++ b/rootski_api/src/rootski/schemas/core.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
-
 from rootski.services.auth import AuthService
 from rootski.services.database import DBService
+from rootski.services.database.dynamo.db_service import DBService as DynamoDBService
 from rootski.services.logger import LoggingService
 
 
@@ -9,6 +9,7 @@ class Services(BaseModel):
     auth: AuthService
     db: DBService
     logger: LoggingService
+    dynamo: DynamoDBService
 
     class Config:
         # allow members of Services to have types that are not pydantic schemas

--- a/rootski_api/src/rootski/schemas/word.py
+++ b/rootski_api/src/rootski/schemas/word.py
@@ -34,7 +34,7 @@ class Word(BaseModel):
     word: str
     accent: str
     pos: WORD_POS_ENUM
-    frequency: int
+    frequency: Optional[int]
 
     class Config:
         orm_mode = True
@@ -99,26 +99,26 @@ class WordResponse(BaseModel):
 
 
 class NounDeclensions(BaseModel):
-    gender: Literal["m", "f", "n"]
-    animate: bool
-    indeclinable: bool
+    gender: Optional[Literal["m", "f", "n"]]
+    animate: Optional[bool]
+    indeclinable: Optional[bool]
 
-    nom: str
-    acc: str
-    prep: str
-    gen: str
-    dat: str
-    inst: str
-    nom_pl: str
-    acc_pl: str
-    prep_pl: str
-    gen_pl: str
-    dat_pl: str
-    inst_pl: str
+    nom: Optional[str]
+    acc: Optional[str]
+    prep: Optional[str]
+    gen: Optional[str]
+    dat: Optional[str]
+    inst: Optional[str]
+    nom_pl: Optional[str]
+    acc_pl: Optional[str]
+    prep_pl: Optional[str]
+    gen_pl: Optional[str]
+    dat_pl: Optional[str]
+    inst_pl: Optional[str]
 
 
 class NounResponse(WordResponse):
-    declensions: NounDeclensions
+    declensions: Optional[NounDeclensions]
 
 
 #############################
@@ -127,15 +127,15 @@ class NounResponse(WordResponse):
 
 
 class AdjectiveShortForms(BaseModel):
-    comp: str
-    fem_short: str
-    masc_short: str
-    neut_short: str
-    plural_short: str
+    comp: Optional[str]
+    fem_short: Optional[str]
+    masc_short: Optional[str]
+    neut_short: Optional[str]
+    plural_short: Optional[str]
 
 
 class AdjectiveResponse(WordResponse):
-    short_forms: AdjectiveShortForms
+    short_forms: Optional[AdjectiveShortForms]
 
 
 #########################
@@ -144,31 +144,31 @@ class AdjectiveResponse(WordResponse):
 
 
 class VerbConjugations(BaseModel):
-    aspect: Literal["perf", "impv"]
-    c__1st_per_sing: str = Field(alias="1st_per_sing")
-    c__2nd_per_sing: str = Field(alias="2nd_per_sing")
-    c__3rd_per_sing: str = Field(alias="3rd_per_sing")
-    c__1st_per_pl: str = Field(alias="1st_per_pl")
-    c__2nd_per_pl: str = Field(alias="2nd_per_pl")
-    c__3rd_per_pl: str = Field(alias="3rd_per_pl")
-    past_m: str
-    past_f: str
-    past_n: str
-    past_pl: str
+    aspect: Optional[Literal["perf", "impf"]]
+    c__1st_per_sing: Optional[str] = Field(alias="1st_per_sing")
+    c__2nd_per_sing: Optional[str] = Field(alias="2nd_per_sing")
+    c__3rd_per_sing: Optional[str] = Field(alias="3rd_per_sing")
+    c__1st_per_pl: Optional[str] = Field(alias="1st_per_pl")
+    c__2nd_per_pl: Optional[str] = Field(alias="2nd_per_pl")
+    c__3rd_per_pl: Optional[str] = Field(alias="3rd_per_pl")
+    past_m: Optional[str]
+    past_f: Optional[str]
+    past_n: Optional[str]
+    past_pl: Optional[str]
     actv_part: Optional[str]
     pass_part: Optional[str]
-    actv_past_part: str
-    pass_past_part: str
-    gerund: str
-    impr: str
-    impr_pl: str
+    actv_past_part: Optional[str]
+    pass_past_part: Optional[str]
+    gerund: Optional[str]
+    impr: Optional[str]
+    impr_pl: Optional[str]
 
 
 class VerbAspectualPair(BaseModel):
-    imp_word_id: str
-    imp_accent: str
-    pfv_word_id: str
-    pfv_accent: str
+    imp_word_id: Optional[str]
+    imp_accent: Optional[str]
+    pfv_word_id: Optional[str]
+    pfv_accent: Optional[str]
 
 
 class VerbResponse(WordResponse):

--- a/rootski_api/src/rootski/schemas/word.py
+++ b/rootski_api/src/rootski/schemas/word.py
@@ -1,7 +1,6 @@
-from typing import List, Literal
+from typing import List, Literal, Optional
 
-from pydantic import BaseModel
-
+from pydantic import BaseModel, Field
 from rootski.schemas import BreakdownInDB
 
 WORD_POS_ENUM = Literal[
@@ -31,7 +30,7 @@ WORD_POS_ENUM = Literal[
 
 
 class Word(BaseModel):
-    id: int
+    word_id: str
     word: str
     accent: str
     pos: WORD_POS_ENUM
@@ -47,3 +46,131 @@ class WordInDb(Word):
     class Config:
         use_enum_values = True
         orm_mode = True
+
+
+#######################
+# --- Definitions --- #
+#######################
+
+
+class SubDefinition(BaseModel):
+    sub_def_id: int
+    sub_def_position: int
+    definition: str
+    notes: Optional[str]
+
+
+class Definition(BaseModel):
+    def_position: int
+    definition_id: int
+    sub_defs: List[SubDefinition]
+
+
+class DefinitionForPOS(BaseModel):
+    pos: WORD_POS_ENUM
+    definitions: List[Definition]
+
+
+#############################
+# --- Example Sentences --- #
+#############################
+
+
+class ExampleSentence(BaseModel):
+    rus: str
+    eng: str
+    exact_match: bool
+
+
+#########################
+# --- Base Response --- #
+#########################
+
+
+class WordResponse(BaseModel):
+    word: Word
+    definitions: List[DefinitionForPOS]
+    sentences: List[ExampleSentence]
+
+
+#########################
+# --- Noun Response --- #
+#########################
+
+
+class NounDeclensions(BaseModel):
+    gender: Literal["m", "f", "n"]
+    animate: bool
+    indeclinable: bool
+
+    nom: str
+    acc: str
+    prep: str
+    gen: str
+    dat: str
+    inst: str
+    nom_pl: str
+    acc_pl: str
+    prep_pl: str
+    gen_pl: str
+    dat_pl: str
+    inst_pl: str
+
+
+class NounResponse(WordResponse):
+    declensions: NounDeclensions
+
+
+#############################
+# --- AdjectiveResponse --- #
+#############################
+
+
+class AdjectiveShortForms(BaseModel):
+    comp: str
+    fem_short: str
+    masc_short: str
+    neut_short: str
+    plural_short: str
+
+
+class AdjectiveResponse(WordResponse):
+    short_forms: AdjectiveShortForms
+
+
+#########################
+# --- Verb Response --- #
+#########################
+
+
+class VerbConjugations(BaseModel):
+    aspect: Literal["perf", "impv"]
+    c__1st_per_sing: str = Field(alias="1st_per_sing")
+    c__2nd_per_sing: str = Field(alias="2nd_per_sing")
+    c__3rd_per_sing: str = Field(alias="3rd_per_sing")
+    c__1st_per_pl: str = Field(alias="1st_per_pl")
+    c__2nd_per_pl: str = Field(alias="2nd_per_pl")
+    c__3rd_per_pl: str = Field(alias="3rd_per_pl")
+    past_m: str
+    past_f: str
+    past_n: str
+    past_pl: str
+    actv_part: Optional[str]
+    pass_part: Optional[str]
+    actv_past_part: str
+    pass_past_part: str
+    gerund: str
+    impr: str
+    impr_pl: str
+
+
+class VerbAspectualPair(BaseModel):
+    imp_word_id: str
+    imp_accent: str
+    pfv_word_id: str
+    pfv_accent: str
+
+
+class VerbResponse(WordResponse):
+    conjugations: VerbConjugations
+    aspectual_pairs: List[VerbAspectualPair]

--- a/rootski_api/src/rootski/services/database/dynamo/actions/dynamo.py
+++ b/rootski_api/src/rootski/services/database/dynamo/actions/dynamo.py
@@ -1,0 +1,9 @@
+from mypy_boto3_dynamodb.type_defs import GetItemOutputTableTypeDef
+
+
+def get_item_status_code(item_output: GetItemOutputTableTypeDef) -> int:
+    return item_output["ResponseMetadata"]["HTTPStatusCode"]
+
+
+def get_item_from_dynamo_response(item_output: GetItemOutputTableTypeDef) -> dict:
+    return item_output["Item"]

--- a/rootski_api/src/rootski/services/database/dynamo/actions/word.py
+++ b/rootski_api/src/rootski/services/database/dynamo/actions/word.py
@@ -1,0 +1,24 @@
+from rootski.services.database.dynamo.actions.dynamo import get_item_from_dynamo_response, get_item_status_code
+from rootski.services.database.dynamo.db_service import DBService
+from rootski.services.database.dynamo.models import word
+
+
+class WordNotFoundError(Exception):
+    """Error thrown if a word isn't found."""
+
+
+def get_word_by_id(word_id: str, db: DBService) -> word.Word:
+    """Query a word from Dynamo matching the ``word_id``.
+
+    :raises WordNotFoundError: raised if no word exists with the given ``word_id``.
+    """
+    table = db.rootski_table
+    word_dynamo_keys: dict = word.make_keys(word_id=word_id)
+
+    get_item_response = table.get_item(Key=word_dynamo_keys)
+    if get_item_status_code(item_output=get_item_response) == 404:
+        raise WordNotFoundError(f"No word with ID {word_id} was found in Dynamo.")
+
+    item = get_item_from_dynamo_response(get_item_response)
+    word_ = word.Word(data=item)
+    return word_

--- a/rootski_api/src/rootski/services/database/dynamo/db_service.py
+++ b/rootski_api/src/rootski/services/database/dynamo/db_service.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Type
+
+import boto3
+from mypy_boto3_dynamodb.service_resource import _Table
+from rootski.config.config import Config
+from rootski.services.service import Service
+
+
+class DBService(Service):
+    def __init__(self, dynamo_table_name: str):
+        self.dynamo_table_name: str = dynamo_table_name
+
+    def init(self):
+        self.rootski_table: _Table = boto3.resource("dynamodb").Table(name=self.dynamo_table_name)
+
+    @classmethod
+    def from_config(cls: Type[DBService], config: Config):
+        return cls(dynamo_table_name=config.dynamo_table_name)

--- a/rootski_api/src/rootski/services/database/dynamo/models/__init__.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models/__init__.py
@@ -1,0 +1,5 @@
+from .morpheme import Morpheme
+from .morpheme_family import MorphemeFamily
+from .word import Word
+
+__all__ = ["Word", "Morpheme", "MorphemeFamily"]

--- a/rootski_api/src/rootski/services/database/dynamo/models/base.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models/base.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True, eq=True)
+class DynamoModel:
+    @property
+    def pk(self) -> str:
+        """Return the partition key of the model."""
+        raise NotImplementedError()
+
+    @property
+    def sk(self) -> str:
+        """Return the sort key of the model."""
+        raise NotImplementedError()
+
+    @property
+    def gsi1pk(self) -> Optional[str]:
+        """Return the model's partition key in the first global secondary index."""
+        return None
+
+    @property
+    def gsi1sk(self) -> Optional[str]:
+        """Return the model's sort key in the first global secondary index."""
+        return None
+
+    @property
+    def keys(self) -> Dict[str, str]:
+
+        gsi1_keys: Dict[str, str] = (
+            {"gsi1pk": self.gsi1pk, "gsi1sk": self.gsi1sk} if self.gsi1pk and self.gsi1sk else {}
+        )
+
+        return {
+            "pk": self.pk,
+            "sk": self.sk,
+            **gsi1_keys,
+        }
+
+    def to_item(self) -> dict:
+        raise NotImplementedError()
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} {self.__dict__}>"

--- a/rootski_api/src/rootski/services/database/dynamo/models/morpheme.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models/morpheme.py
@@ -1,0 +1,70 @@
+"""
+NOTE: remember to cast all IDs to strings
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Literal
+
+from rootski.services.database.dynamo.models.base import DynamoModel
+
+
+@dataclass
+class Morpheme(DynamoModel):
+
+    morpheme: str
+    morpheme_id: str
+    family_id: str
+
+    __type: Literal["MORPHEME"] = "MORPHEME"
+
+    @property
+    def pk(self) -> str:
+        return make_pk(family_id=self.family_id)
+
+    @property
+    def sk(self) -> str:
+        return make_sk(morpheme_id=self.morpheme_id)
+
+    @property
+    def gsi1pk(self) -> str:
+        return make_gsi1pk(morpheme_id=self.morpheme_id)
+
+    @property
+    def gsi1sk(self) -> str:
+        return make_gsi1sk(morpheme_id=self.morpheme_id)
+
+    def to_item(self) -> dict:
+        return {
+            **self.keys,
+            "__type": self.__type,
+            "family_id": self.family_id,
+            "morpheme": self.morpheme,
+            "morpheme_id": self.morpheme_id,
+        }
+
+
+def make_pk(family_id: str) -> str:
+    return f"MORPHEME_FAMILY#{family_id}"
+
+
+def make_sk(morpheme_id: str) -> str:
+    return f"MORPHEME#{morpheme_id}"
+
+
+def make_gsi1pk(morpheme_id: str) -> str:
+    return make_sk(morpheme_id=morpheme_id)
+
+
+def make_gsi1sk(morpheme_id: str) -> str:
+    return make_sk(morpheme_id=morpheme_id)
+
+
+def make_keys(family_id: str, morpheme_id: str) -> Dict[str, str]:
+    return {"pk": make_pk(family_id=family_id), "sk": make_sk(morpheme_id=morpheme_id)}
+
+
+def make_gsi1_keys(morpheme_id: str) -> Dict[str, str]:
+    return {
+        "gsi1pk": make_gsi1pk(morpheme_id=morpheme_id),
+        "gsi1sk": make_gsi1sk(morpheme_id=morpheme_id),
+    }

--- a/rootski_api/src/rootski/services/database/dynamo/models/morpheme_family.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models/morpheme_family.py
@@ -1,0 +1,58 @@
+"""
+NOTE: remember to cast all IDs to strings
+"""
+
+from dataclasses import dataclass
+from typing import List, Literal, TypedDict
+
+from rootski.schemas.morpheme import MORPHEME_TYPE_ENUM, MORPHEME_WORD_POS_ENUM
+from rootski.services.database.dynamo.models.base import DynamoModel
+from rootski.services.database.dynamo.models.morpheme import Morpheme
+
+
+class MorphemeItem(TypedDict):
+    morpheme_id: str
+    morpheme: str
+
+
+@dataclass
+class MorphemeFamily(DynamoModel):
+
+    type: MORPHEME_TYPE_ENUM
+    word_pos: MORPHEME_WORD_POS_ENUM
+    family_id: str  # these should be converted to strings
+    family_meanings: List[str]
+    level: int
+    morphemes: List[MorphemeItem]
+
+    __type: Literal["MORPHEME_FAMILY"] = "MORPHEME_FAMILY"
+
+    @property
+    def pk(self) -> str:
+        return f"MORPHEME_FAMILY#{self.family_id}"
+
+    @property
+    def sk(self) -> str:
+        return self.pk
+
+    def to_item(self) -> dict:
+        return {
+            **self.keys,
+            "__type": self.__type,
+            "type": self.type,
+            "word_pos": self.word_pos,
+            "family_id": str(self.family_id),
+            "level": self.level,
+            "morphemes": self.morphemes,
+            "family_meanings": self.family_meanings,
+        }
+
+    def create_morphemes(self) -> List[Morpheme]:
+        return [
+            Morpheme(
+                family_id=self.family_id,
+                morpheme=m["morpheme"],
+                morpheme_id=str(m["morpheme_id"]),
+            )
+            for m in self.morphemes
+        ]

--- a/rootski_api/src/rootski/services/database/dynamo/models/word.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models/word.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+from typing import Dict, Literal, TypedDict
+
+from rootski.services.database.dynamo.models.base import DynamoModel
+
+WORD_POS_ENUM = Literal[
+    "noun", "adjective", "verb", "adverb", "particle", "preposition", "pronoun", "conjunction"
+]
+
+
+class Word_(TypedDict):
+    word_id: str
+    word: str
+    accent: str
+    pos: WORD_POS_ENUM
+    frequency: int
+
+
+@dataclass
+class Word(DynamoModel):
+
+    data: dict
+    __type: Literal["WORD"] = "WORD"
+
+    @property
+    def word_id(self) -> str:
+        return str(self.data["word"]["word_id"])
+
+    @property
+    def pk(self) -> str:
+        return make_pk(word_id=self.word_id)
+
+    @property
+    def sk(self) -> str:
+        return make_sk(word_id=self.word_id)
+
+    @property
+    def keys(self) -> Dict[str, str]:
+        return make_keys(word_id=self.word_id)
+
+    @property
+    def word_pos(self) -> str:
+        return self.data["word"]["pos"]
+
+    def to_item(self) -> dict:
+        data = {**self.data}
+        data["word"]["word_id"] = self.word_id
+        return {**self.keys, **data, "__type": self.__type}
+
+
+def make_pk(word_id: str) -> str:
+    return f"WORD#{word_id}"
+
+
+def make_sk(word_id: str) -> str:
+    return make_pk(word_id=word_id)
+
+
+def make_keys(word_id: str) -> Dict[str, str]:
+    return {
+        "pk": make_pk(word_id=word_id),
+        "sk": make_sk(word_id=word_id),
+    }

--- a/rootski_api/src/rootski/services/database/dynamo/models2schemas/word.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models2schemas/word.py
@@ -17,8 +17,13 @@ def dynamo_to_pydantic__word(
     common_word_fields = parse_common_word_schemas(word=word)
 
     if word.word_pos in ["noun", "pronoun"]:
+        declensions_or_none = (
+            schemas.NounDeclensions.parse_obj(word.data["declensions"])
+            if "declensions" in word.data.keys()
+            else None
+        )
         return schemas.NounResponse(
-            declensions=schemas.NounDeclensions(**word.data["declensions"]),
+            declensions=declensions_or_none,
             **common_word_fields,
         )
 
@@ -30,9 +35,10 @@ def dynamo_to_pydantic__word(
         )
 
     if word.word_pos == "adjective":
-        return schemas.AdjectiveResponse(
-            short_forms=schemas.AdjectiveShortForms(**word.data["short_forms"]), **common_word_fields
-        )
+        short_forms_or_none = None
+        if word.data is not None:
+            schemas.AdjectiveShortForms.parse_obj(word.data)
+        return schemas.AdjectiveResponse(short_forms=short_forms_or_none, **common_word_fields)
 
     return schemas.WordResponse(**common_word_fields)
 

--- a/rootski_api/src/rootski/services/database/dynamo/models2schemas/word.py
+++ b/rootski_api/src/rootski/services/database/dynamo/models2schemas/word.py
@@ -1,0 +1,79 @@
+from typing import List, TypedDict, Union
+
+import rootski.services.database.dynamo.models as dynamo
+from rootski.schemas import word as schemas
+
+
+class CommonWordSchemas(TypedDict):
+    word: schemas.Word
+    definitions: List[schemas.DefinitionForPOS]
+    sentences: List[schemas.ExampleSentence]
+
+
+def dynamo_to_pydantic__word(
+    word: dynamo.Word,
+) -> Union[schemas.WordResponse, schemas.AdjectiveResponse, schemas.NounResponse, schemas.VerbResponse]:
+
+    common_word_fields = parse_common_word_schemas(word=word)
+
+    if word.word_pos in ["noun", "pronoun"]:
+        return schemas.NounResponse(
+            declensions=schemas.NounDeclensions(**word.data["declensions"]),
+            **common_word_fields,
+        )
+
+    if word.word_pos == "verb":
+        return schemas.VerbResponse(
+            aspectual_pairs=[schemas.VerbAspectualPair(**pair) for pair in word.data["aspectual_pairs"]],
+            conjugations=schemas.VerbConjugations.parse_obj(word.data["conjugations"]),
+            **common_word_fields,
+        )
+
+    if word.word_pos == "adjective":
+        return schemas.AdjectiveResponse(
+            short_forms=schemas.AdjectiveShortForms(**word.data["short_forms"]), **common_word_fields
+        )
+
+    return schemas.WordResponse(**common_word_fields)
+
+
+def parse_common_word_schemas(word: dynamo.Word) -> CommonWordSchemas:
+    word_ = schemas.Word(**word.data["word"])
+
+    definitions = [
+        schemas.DefinitionForPOS(
+            pos=d["pos"],
+            definitions=[
+                schemas.Definition(
+                    def_position=def_["def_position"],
+                    definition_id=def_["definition_id"],
+                    sub_defs=[
+                        schemas.SubDefinition(
+                            sub_def_id=sub_def["sub_def_id"],
+                            notes=sub_def["notes"],
+                            definition=sub_def["definition"],
+                            sub_def_position=sub_def["sub_def_position"],
+                        )
+                        for sub_def in def_["sub_defs"]
+                    ],
+                )
+                for def_ in d["definitions"]
+            ],
+        )
+        for d in word.data["definitions"]
+    ]
+
+    sentences = [
+        schemas.ExampleSentence(
+            eng=s["eng"],
+            rus=s["rus"],
+            exact_match=s["exact_match"],
+        )
+        for s in word.data["sentences"]
+    ]
+
+    return {
+        "word": word_,
+        "definitions": definitions,
+        "sentences": sentences,
+    }

--- a/rootski_api/tests/unit_tests/services/database/dynamo/models2schemas/test__word.py
+++ b/rootski_api/tests/unit_tests/services/database/dynamo/models2schemas/test__word.py
@@ -1,0 +1,380 @@
+from rootski.services.database.dynamo.models import Word
+from rootski.services.database.dynamo.models2schemas.word import dynamo_to_pydantic__word
+
+from rootski import schemas
+
+EXAMPLE_VERB = {
+    "word": {"word_id": 2004, "word": "запретить", "accent": "запрети'ть", "pos": "verb", "frequency": 2004},
+    "definitions": [
+        {
+            "pos": "verb",
+            "definitions": [
+                {
+                    "def_position": 1,
+                    "definition_id": 12149,
+                    "sub_defs": [
+                        {
+                            "sub_def_id": 12150,
+                            "sub_def_position": 1,
+                            "definition": "forbid, prohibit, interdict, ban, outlaw",
+                            "notes": None,
+                        },
+                        {
+                            "sub_def_id": 12151,
+                            "sub_def_position": 2,
+                            "definition": "suppress",
+                            "notes": "(публикацию)",
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+    "sentences": [
+        {
+            "rus": "Книга, которую нужно запретить прежде всего, - это каталог запрещённых книг.",
+            "eng": "A book which, above all others in the world, should be forbidden, is a catalogue of forbidden books.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Львовский городской совет ещё раз обращает ваше внимание на ложную информацию относительно намерения запретить разговаривать во Львове по-русски.",
+            "eng": "The Lvov city council is once more drawing attention to False information regarding the intention to ban speaking Russian in Lvov.",
+            "exact_match": True,
+        },
+        {"rus": "Это надо запретить.", "eng": "That should be prohibited.", "exact_match": True},
+        {
+            "rus": "Нужно запретить рекламу, нацеленную на детей.",
+            "eng": "We should ban advertising aimed towards children.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Вам благословляется всё, что не в состоянии запретить церковь.",
+            "eng": "What the church can't prohibit it blesses.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Ему запретили заниматься медициной.",
+            "eng": "He was banned from practising medicine.",
+            "exact_match": False,
+        },
+        {"rus": "Эта тема здесь под запретом.", "eng": "The topic is taboo here.", "exact_match": False},
+        {
+            "rus": "Запрет никем не принимается всерьёз.",
+            "eng": "Prohibition isn't taken seriously by anyone.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Врачи запретили Тому дальние поездки.",
+            "eng": "The doctors prohibited Tom from taking any long trips.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Отец запретил мне заводить кота.",
+            "eng": "My father forbade me from having a pet cat.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Автостоп в Австралии под запретом?",
+            "eng": "Is hitchhiking prohibited in Australia?",
+            "exact_match": False,
+        },
+        {
+            "rus": "Им запретили покидать отель.",
+            "eng": "They were prohibited from leaving the hotel.",
+            "exact_match": False,
+        },
+        {"rus": "Вы не запрете дверь?", "eng": "Would you please lock the door?", "exact_match": False},
+    ],
+    "conjugations": {
+        "aspect": "perf",
+        "1st_per_sing": "запрещу'",
+        "2nd_per_sing": "запре'тишь",
+        "3rd_per_sing": "запрети'т",
+        "1st_per_pl": "запрети'м",
+        "2nd_per_pl": "запрети'те",
+        "3rd_per_pl": "запре'тят",
+        "past_m": "запрети'л",
+        "past_f": "запрети'ла",
+        "past_n": "запрети'ло",
+        "past_pl": "запрети'ли",
+        "actv_part": None,
+        "pass_part": None,
+        "actv_past_part": "запрети'вший",
+        "pass_past_part": "запрещённый",
+        "gerund": "запрети'в",
+        "impr": "запрети'",
+        "impr_pl": "запрети'те",
+    },
+    "aspectual_pairs": [
+        {"imp_word_id": 4674, "imp_accent": "запреща'ть", "pfv_word_id": 2004, "pfv_accent": "запрети'ть"}
+    ],
+}
+
+EXAMPLE_ADVERB = {
+    "word": {"word_id": 2005, "word": "жаль", "accent": "жаль", "pos": "adverb", "frequency": 2005},
+    "definitions": [
+        {
+            "pos": "adverb",
+            "definitions": [
+                {
+                    "def_position": 1,
+                    "definition_id": 12152,
+                    "sub_defs": [
+                        {
+                            "sub_def_id": 12153,
+                            "sub_def_position": 1,
+                            "definition": "be/feel sorry (for smb.)",
+                            "notes": "(кого-л./что-л.)",
+                        },
+                        {"sub_def_id": 12154, "sub_def_position": 2, "definition": "pity", "notes": None},
+                        {"sub_def_id": 12155, "sub_def_position": 3, "definition": "regret", "notes": None},
+                    ],
+                },
+                {
+                    "def_position": 2,
+                    "definition_id": 12156,
+                    "sub_defs": [
+                        {
+                            "sub_def_id": 12157,
+                            "sub_def_position": 1,
+                            "definition": "it is a pity",
+                            "notes": "(прискорбно)",
+                        }
+                    ],
+                },
+                {
+                    "def_position": 3,
+                    "definition_id": 12158,
+                    "sub_defs": [
+                        {
+                            "sub_def_id": 12159,
+                            "sub_def_position": 1,
+                            "definition": "grudge",
+                            "notes": "(чего-л.; делать что-л.)",
+                        }
+                    ],
+                },
+            ],
+        }
+    ],
+    "sentences": [
+        {"rus": "Очень жаль.", "eng": "That's too bad.", "exact_match": True},
+        {"rus": "Жаль.", "eng": "That's a shame.", "exact_match": True},
+        {"rus": "Жаль.", "eng": "This is unfortunate.", "exact_match": True},
+        {"rus": "Жаль...", "eng": "Pity...", "exact_match": True},
+        {"rus": "Мне жаль!", "eng": "Sorry!", "exact_match": True},
+        {"rus": "Мне жаль.", "eng": "I feel sorry.", "exact_match": True},
+        {"rus": "Мне жаль.", "eng": "I apologize.", "exact_match": True},
+        {"rus": "Мне жаль.", "eng": "Excuse me.", "exact_match": True},
+        {"rus": "Нам жаль.", "eng": "We're sorry.", "exact_match": True},
+        {"rus": "Тому жаль.", "eng": "Tom's sorry.", "exact_match": True},
+        {"rus": "Не жалуйся.", "eng": "Don't complain.", "exact_match": False},
+        {"rus": "Кто жалуется?", "eng": "Who's complaining?", "exact_match": False},
+    ],
+}
+
+EXAMPLE_NOUN = {
+    "word": {"word_id": 2006, "word": "демократия", "accent": "демокра'тия", "pos": "noun", "frequency": 2006},
+    "definitions": [
+        {
+            "pos": "noun",
+            "definitions": [
+                {
+                    "def_position": 1,
+                    "definition_id": 12160,
+                    "sub_defs": [
+                        {"sub_def_id": 12161, "sub_def_position": 1, "definition": "democracy", "notes": None}
+                    ],
+                }
+            ],
+        }
+    ],
+    "sentences": [
+        {
+            "rus": "В Испании демократия с 1975 года.",
+            "eng": "Spain has been a democracy since 1975.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Представительная демократия — это одна из форм государственной власти.",
+            "eng": "Representative democracy is one form of government.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Демократия — наихудшая форма правления, если не считать всех остальных.",
+            "eng": "Democracy is the worst form of government, except all the others that have been tried.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Демократия — это форма правления.",
+            "eng": "Democracy is one form of government.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Демократия - это диктатура большинства.",
+            "eng": "Democracy is the dictatorship of the majority.",
+            "exact_match": True,
+        },
+        {
+            "rus": "Когда возникла демократия?",
+            "eng": "When did Democracy come into existence?",
+            "exact_match": True,
+        },
+        {
+            "rus": "Германия - парламентская демократия.",
+            "eng": "Germany is a parliamentary democracy.",
+            "exact_match": True,
+        },
+        {"rus": "Демократия поощряет свободу.", "eng": "Democracy encourages freedom.", "exact_match": True},
+        {
+            "rus": "Демократия возникла в Древней Греции.",
+            "eng": "Democracy originated in Ancient Greece.",
+            "exact_match": True,
+        },
+        {"rus": "Мы защищаем демократию.", "eng": "We stand for democracy.", "exact_match": False},
+        {"rus": "Я демократ.", "eng": "I'm a democrat.", "exact_match": False},
+        {"rus": "Он убеждённый демократ.", "eng": "He is heart and soul a Democrat.", "exact_match": False},
+        {"rus": "Том демократ.", "eng": "Tom is a democrat.", "exact_match": False},
+    ],
+    "declensions": {
+        "gender": "f",
+        "animate": False,
+        "indeclinable": False,
+        "nom": "демокра'тия",
+        "acc": "демокра'тию",
+        "prep": "демокра'тии",
+        "gen": "демокра'тии",
+        "dat": "демокра'тии",
+        "inst": "демокра'тией",
+        "nom_pl": "демокра'тии",
+        "acc_pl": "демокра'тии",
+        "prep_pl": "демокра'тиях",
+        "gen_pl": "демокра'тий",
+        "dat_pl": "демокра'тиям",
+        "inst_pl": "демокра'тиями",
+    },
+}
+
+EXAMPLE_ADJECTIVE = {
+    "word": {"word_id": 2017, "word": "судебный", "accent": "суде'бный", "pos": "adjective", "frequency": 2017},
+    "definitions": [
+        {
+            "pos": "adjective",
+            "definitions": [
+                {
+                    "def_position": 1,
+                    "definition_id": 12208,
+                    "sub_defs": [
+                        {
+                            "sub_def_id": 12209,
+                            "sub_def_position": 1,
+                            "definition": "judicial, legal, forensic",
+                            "notes": None,
+                        },
+                        {"sub_def_id": 12210, "sub_def_position": 2, "definition": "law", "notes": None},
+                        {"sub_def_id": 12211, "sub_def_position": 3, "definition": "court", "notes": None},
+                        {"sub_def_id": 12212, "sub_def_position": 4, "definition": "coroner", "notes": None},
+                    ],
+                }
+            ],
+        }
+    ],
+    "sentences": [
+        {
+            "rus": "Расклеивание рекламы запрещено. Нарушители будут преследоваться в судебном порядке.",
+            "eng": "Bill posting prohibited. Offenders will be prosecuted.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Судебно-медицинский эксперт не обнаружил огнестрельных ранений ни у одного из трупов.",
+            "eng": "The coroner didn't find any gunshot wounds on any of the bodies.",
+            "exact_match": False,
+        },
+        {
+            "rus": "В США просто потрясающая судебная система и пресса: сегодня ты являешь собой пример бедной домохозяйки, жертвы изнасилования, а завтра ты нелегальная мигрантка, совершившая лжесвидетельство и подозреваемая в отмывании денег, связанных с наркоторговлей.",
+            "eng": "The US judicial system and press are incredible: One day you're a poor examplary housewife, victim of a rape, the next, you're an illegal immigrant, having committed perjury and being suspected of whitewashing drug money.",
+            "exact_match": False,
+        },
+        {
+            "rus": 'Слово "okazo" изначально значило на эсперанто как "то, что случается", так и "конкретное происшествие" - так же, как русское "случай", а "kazo" значило лишь "падеж в склонении". Под западным влиянием "kazo" стало значить "судебное дело", а потом и "случай вообще".',
+            "eng": "The Esperanto word ‘okazo’ originally meant both ‘occasion’ and ‘case’, as the Russian ‘случай’ does, while ‘kazo’ only meant ‘case in declension’. Owing to Western influence, ‘kazo’ started to mean ‘case in court’, then ‘case in general’.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Правительство США имеет три ветви власти: исполнительную, законодательную и судебную.",
+            "eng": "The U.S. government has three branches: the executive, the legislative, and the judicial.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Мне нужно судебное дело, составленное по этому материалу.",
+            "eng": "I want a suit made of this material.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Я предпочту любую альтернативу судебному процессу.",
+            "eng": "I would prefer any alternative to a lawsuit.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Вы когда-нибудь выступали свидетелем на судебном процессе?",
+            "eng": "Have you ever been a witness in a court case?",
+            "exact_match": False,
+        },
+        {
+            "rus": "Я не имею никакого понятия о судебной процедуре.",
+            "eng": "I have no acquaintance with court procedure.",
+            "exact_match": False,
+        },
+        {
+            "rus": "Татоэба вдохновила Мэри, известного судебного психолога, на написание романа о Томе, серийном убийце из Бостона.",
+            "eng": "Mary, the famous forensic psychologist and writer, was inspired by Tatoeba to write a novel about Tom, the serial killer from Boston.",
+            "exact_match": False,
+        },
+    ],
+    "short_forms": {
+        "comp": "суде'бнее",
+        "fem_short": "суде'бна",
+        "masc_short": "суде'бен",
+        "neut_short": "суде'бно",
+        "plural_short": "суде'бны",
+    },
+}
+
+
+def test__dynamo_to_pydantic__word__verb():
+    verb = Word(data=EXAMPLE_VERB)
+    verb_response: schemas.VerbResponse = dynamo_to_pydantic__word(word=verb)
+    assert type(verb_response) is schemas.VerbResponse
+
+    verb_response_dict = verb_response.dict(by_alias=True)
+    assert all(field in verb_response_dict.keys() for field in ["aspectual_pairs", "conjugations"])
+
+
+def test__dynamo_to_pydantic__word__noun():
+    noun = Word(data=EXAMPLE_NOUN)
+    noun_response: schemas.NounResponse = dynamo_to_pydantic__word(word=noun)
+    assert type(noun_response) is schemas.NounResponse
+
+    noun_response_dict = noun_response.dict(by_alias=True)
+    assert all(field in noun_response_dict.keys() for field in ["declensions"])
+
+
+def test__dynamo_to_pydantic__word__adjective():
+    adjective = Word(data=EXAMPLE_ADJECTIVE)
+    adjective_response: schemas.AdjectiveResponse = dynamo_to_pydantic__word(word=adjective)
+    assert type(adjective_response) is schemas.AdjectiveResponse
+
+    adjective_response_dict = adjective_response.dict(by_alias=True)
+    assert all(field in adjective_response_dict.keys() for field in ["short_forms"])
+
+
+def test__dynamo_to_pydantic__word__adverb():
+    adverb = Word(data=EXAMPLE_ADVERB)
+    adverb_response: schemas.WordResponse = dynamo_to_pydantic__word(word=adverb)
+    assert type(adverb_response) is schemas.WordResponse
+
+    adverb_response_dict = adverb_response.dict(by_alias=True)
+    assert all(
+        field not in adverb_response_dict.keys()
+        for field in ["aspectual_pairs", "conjugations", "declensions", "short_forms"]
+    )


### PR DESCRIPTION
Many pydantic schemas have been added so that the `GET /word` endpoint is documented.

The beginnings of the transition to DynamoDB are now in place for this endpoint.

<img width="704" alt="image" src="https://user-images.githubusercontent.com/32227767/181120635-b29c6607-b1df-4fe2-936b-839a44a5df1d.png">
